### PR TITLE
League component & route handling

### DIFF
--- a/client/src/components/league.jsx
+++ b/client/src/components/league.jsx
@@ -1,8 +1,49 @@
 import React from 'react';
+import {
+  Table,
+  TableBody,
+  TableHeader,
+  TableHeaderColumn,
+  TableRow,
+  TableRowColumn,
+} from 'material-ui/Table';
 
-const League = () => {
+const fakeTeamsInfo = [
+  {'id': 1234, 'name': 'Team1', 'coach': 'reenuka', 'league': 1, 'wins': 3, 'losses': 0},
+  {'id': 2345, 'name': 'Team2', 'coach': 'daharlow', 'league': 1, 'wins': 2, 'losses': 1},
+  {'id': 3456, 'name': 'Team3', 'coach': 'mcooper', 'league': 1, 'wins': 1, 'losses': 2},
+  {'id': 4567, 'name': 'Team4', 'coach': 'fcatania', 'league': 1, 'wins': 0, 'losses': 3},
+]
+// Should the list of teams come from App.jsx as props ?
+// It will be faster if we keep that info as a state in the app component.
+const League = (props) => {
   return (
-    <p>League</p>
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHeaderColumn>Position</TableHeaderColumn>
+          <TableHeaderColumn>Team Name</TableHeaderColumn>
+          <TableHeaderColumn>Coach</TableHeaderColumn>
+          <TableHeaderColumn>Wins</TableHeaderColumn>
+          <TableHeaderColumn>Losses</TableHeaderColumn>
+        </TableRow>
+      </TableHeader>
+      
+      <TableBody>
+        {fakeTeamsInfo.map( (team, index) => {
+          return (
+            <TableRow>
+              <TableRowColumn>{index + 1}</TableRowColumn>
+              <TableRowColumn>{team.name}</TableRowColumn>
+              <TableRowColumn>{team.coach}</TableRowColumn>
+              <TableRowColumn>{team.wins}</TableRowColumn>
+              <TableRowColumn>{team.losses}</TableRowColumn>
+            </TableRow>
+          )
+        })}
+      </TableBody>
+
+    </Table>
   );
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -21,4 +21,5 @@ app
 	.post('/playerdata/:season/:week', (req, res) => fdsApi.getAllPlayerStatsFromApi(req.params.season, req.params.week, res))
 	.put('/week', (req, res) => db.updateCurrentWeek(req.body.week, res))
 	.put('/playerdata/:season/:week', (req, res) => fdsApi.updateAllPlayerStatsFromApi(req.params.season, req.params.week, res))
+	.get('*', (req, res) => res.sendFile(path.join(__dirname, '../client/dist/index.html')))
 	.listen(port, '0.0.0.0', () => console.log(`express listening on port ${port}`));


### PR DESCRIPTION
There is a small bug in the rendering if you type the route directly in the browser, and that is because the 'isLoggedIn' state of the app is False whenever you enter the route by yourself.
-- Easy fix would be sending the user to the login route whenever isLoggedIn = False

I am waiting for Reenuka's big merge on the App.jsx so that we don't get any conflicts right now.